### PR TITLE
Fix manage settings path and string comparison in view

### DIFF
--- a/cat_django/views.py
+++ b/cat_django/views.py
@@ -9,7 +9,7 @@ from cat_django.models import Enigme
 
 def enigme(request):
     _id = request.GET.get("id", "-1")
-    if _id is "-1":
+    if _id == "-1":
         return HttpResponse("pas bon")
     else:
         e = Enigme.objects.get(id_enigme=_id)

--- a/manage.py
+++ b/manage.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "CatDjango.settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cat_django.settings")
 
     from django.core.management import execute_from_command_line
 


### PR DESCRIPTION
## Summary
- fix string comparison using `==` in `views.py`
- correct the settings module path in `manage.py`

## Testing
- `python -m py_compile manage.py cat_django/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685b64545864832d96ec256e6e6700fc